### PR TITLE
generate-stackbrew-library: Enable AArch64

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -59,6 +59,8 @@ cat <<-EOH
 Maintainers: YOURLS <yourls@yourls.org> (@YOURLS),
              Léo Colombaro <git@colombaro.fr> (@LeoColomb)
 GitRepo: https://github.com/YOURLS/docker-yourls.git
+
+Architectures: amd64, arm64v8
 EOH
 
 # prints "$2$1$3$1...$N"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -36,22 +36,21 @@ dirCommit() {
 	)
 }
 
-# TODO: activate arch variant
-#getArches() {
-#	local repo="$1"; shift
-#	local officialImagesUrl='https://github.com/docker-library/official-images/raw/master/library/'
-#
-#	eval "declare -g -A parentRepoToArches=( $(
-#		find -name 'Dockerfile' -exec awk '
-#				toupper($1) == "FROM" && $2 !~ /^('"$repo"'|scratch|microsoft\/[^:]+)(:|$)/ {
-#					print "'"$officialImagesUrl"'" $2
-#				}
-#			' '{}' + \
-#			| sort -u \
-#			| xargs bashbrew cat --format '[{{ .RepoName }}:{{ .TagName }}]="{{ join " " .TagEntry.Architectures }}"'
-#	) )"
-#}
-#getArches 'yourls'
+getArches() {
+	local repo="$1"; shift
+	local officialImagesUrl='https://github.com/docker-library/official-images/raw/master/library/'
+
+	eval "declare -g -A parentRepoToArches=( $(
+		find -name 'Dockerfile' -exec awk '
+				toupper($1) == "FROM" && $2 !~ /^('"$repo"'|scratch|microsoft\/[^:]+)(:|$)/ {
+					print "'"$officialImagesUrl"'" $2
+				}
+			' '{}' + \
+			| sort -u \
+			| xargs bashbrew cat --format '[{{ .RepoName }}:{{ .TagName }}]="{{ join " " .TagEntry.Architectures }}"'
+	) )"
+}
+getArches 'yourls'
 
 cat <<-EOH
 # this file is generated via https://github.com/YOURLS/docker-yourls/blob/$(fileCommit "$self")/$self
@@ -59,8 +58,6 @@ cat <<-EOH
 Maintainers: YOURLS <yourls@yourls.org> (@YOURLS),
              Léo Colombaro <git@colombaro.fr> (@LeoColomb)
 GitRepo: https://github.com/YOURLS/docker-yourls.git
-
-Architectures: amd64, arm64v8
 EOH
 
 # prints "$2$1$3$1...$N"
@@ -93,12 +90,13 @@ for version in "${versions[@]}"; do
 			variantAliases+=( "${versionAliases[@]}" )
 		fi
 
-#        variantParent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/$variant/Dockerfile")"
-#		variantArches="${parentRepoToArches[$variantParent]}"
+		variantParent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/$variant/Dockerfile")"
+		variantArches="${parentRepoToArches[$variantParent]}"
 
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")
+			Architectures: $(join ', ' $variantArches)
 			GitCommit: $commit
 			Directory: $version/$variant
 		EOE


### PR DESCRIPTION
By default the Docker Images project only builds and pushes (to
Docker Hub) images for AMD64.  In order to support additional
architectures the 'Architectures:' label is used to denote which
ones.

AArch64 has been tested working on all currently supported
versions of YOURLS.  This means we can make the 'Architecture'
global in the library file which simplifies things quite a bit.

Fixes: #11 
Signed-off-by: Lee Jones <lee.jones@linaro.org>