### PR TITLE
Fix boolean environment variables in the configuration (fix #22)

### DIFF
--- a/config-docker.php
+++ b/config-docker.php
@@ -43,12 +43,12 @@ define( 'YOURLS_LANG', getenv('YOURLS_LANG') ?: '' );
 /** Allow multiple short URLs for a same long URL
  ** Set to true to have only one pair of shortURL/longURL (default YOURLS behavior)
  ** Set to false to allow multiple short URLs pointing to the same long URL (bit.ly behavior) */
-define( 'YOURLS_UNIQUE_URLS', getenv('YOURLS_UNIQUE_URLS') == 'false' ? false : true );
+define( 'YOURLS_UNIQUE_URLS', getenv('YOURLS_UNIQUE_URLS') !== 'false' );
 
 /** Private means the Admin area will be protected with login/pass as defined below.
  ** Set to false for public usage (eg on a restricted intranet or for test setups)
  ** Read http://yourls.org/privatepublic for more details if you're unsure */
-define( 'YOURLS_PRIVATE', getenv('YOURLS_PRIVATE') == 'false' ? false : true );
+define( 'YOURLS_PRIVATE', getenv('YOURLS_PRIVATE') !== 'false' );
 
 /** A random secret hash used to encrypt cookies. You don't have to remember it, make it long and complicated. Hint: copy from http://yourls.org/cookie **/
 define( 'YOURLS_COOKIEKEY', getenv('YOURLS_COOKIEKEY') ?: 'modify this text with something random' );

--- a/config-docker.php
+++ b/config-docker.php
@@ -62,7 +62,7 @@ $yourls_user_passwords = [
 
 /** Debug mode to output some internal information
  ** Default is false for live site. Enable when coding or before submitting a new issue */
-define( 'YOURLS_DEBUG', filter_var(getenv('YOURLS_DEBUG'), FILTER_VALIDATE_BOOLEAN));
+define( 'YOURLS_DEBUG', filter_var(getenv('YOURLS_DEBUG'), FILTER_VALIDATE_BOOLEAN) );
 
 /*
 ** URL Shortening settings

--- a/config-docker.php
+++ b/config-docker.php
@@ -43,12 +43,12 @@ define( 'YOURLS_LANG', getenv('YOURLS_LANG') ?: '' );
 /** Allow multiple short URLs for a same long URL
  ** Set to true to have only one pair of shortURL/longURL (default YOURLS behavior)
  ** Set to false to allow multiple short URLs pointing to the same long URL (bit.ly behavior) */
-define( 'YOURLS_UNIQUE_URLS', filter_var(getenv('YOURLS_UNIQUE_URLS'), FILTER_VALIDATE_BOOLEAN) ?: true );
+define( 'YOURLS_UNIQUE_URLS', getenv('YOURLS_UNIQUE_URLS') == 'false' ? false : true );
 
 /** Private means the Admin area will be protected with login/pass as defined below.
  ** Set to false for public usage (eg on a restricted intranet or for test setups)
  ** Read http://yourls.org/privatepublic for more details if you're unsure */
-define( 'YOURLS_PRIVATE', filter_var(getenv('YOURLS_PRIVATE'), FILTER_VALIDATE_BOOLEAN) ?: true );
+define( 'YOURLS_PRIVATE', getenv('YOURLS_PRIVATE') == 'false' ? false : true );
 
 /** A random secret hash used to encrypt cookies. You don't have to remember it, make it long and complicated. Hint: copy from http://yourls.org/cookie **/
 define( 'YOURLS_COOKIEKEY', getenv('YOURLS_COOKIEKEY') ?: 'modify this text with something random' );
@@ -62,7 +62,7 @@ $yourls_user_passwords = [
 
 /** Debug mode to output some internal information
  ** Default is false for live site. Enable when coding or before submitting a new issue */
-define( 'YOURLS_DEBUG', filter_var(getenv('YOURLS_DEBUG'), FILTER_VALIDATE_BOOLEAN) ?: false );
+define( 'YOURLS_DEBUG', filter_var(getenv('YOURLS_DEBUG'), FILTER_VALIDATE_BOOLEAN));
 
 /*
 ** URL Shortening settings


### PR DESCRIPTION
Currently `filter_var(getenv('ENV_VAR'), FILTER_VALIDATE_BOOLEAN) ?: true` will always evaluate to `true`.

We need string comparison for environment variables which have true as default value, because `filter_var(getenv('ENV_VAR'), FILTER_VALIDATE_BOOLEAN)` will be false if ENV_VAR is "false" or empty. Otherwise wo could not differentiate between false and unset variable.