### PR TITLE
Remove volume instructions to exclude caching on host

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,8 +15,6 @@ RUN { \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 %%VARIANT_EXTRAS%%
 
-VOLUME /var/www/html
-
 ENV YOURLS_VERSION %%VERSION%%
 ENV YOURLS_SHA256 %%SHA256%%
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -16,8 +16,6 @@ RUN { \
 
 RUN a2enmod rewrite expires
 
-VOLUME /var/www/html
-
 ENV YOURLS_VERSION 1.7.4
 ENV YOURLS_SHA256 ffdf0f94b66cdbeaaa62bed3fde14d4eeb2bb1669c3c342eef369ce6165a0276
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -16,7 +16,6 @@ RUN { \
 
 RUN a2enmod rewrite expires
 
-
 ENV YOURLS_VERSION 1.7.6
 ENV YOURLS_SHA256 f3623af6e4cabee61a39d3deca3c941717c5e0a60bc288b6f3a668f87a20ae2e
 

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -16,7 +16,6 @@ RUN { \
 
 RUN apk add --no-cache bash
 
-
 ENV YOURLS_VERSION 1.7.6
 ENV YOURLS_SHA256 f3623af6e4cabee61a39d3deca3c941717c5e0a60bc288b6f3a668f87a20ae2e
 

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -16,8 +16,6 @@ RUN { \
 
 RUN apk add --no-cache bash
 
-VOLUME /var/www/html
-
 ENV YOURLS_VERSION 1.7.4
 ENV YOURLS_SHA256 ffdf0f94b66cdbeaaa62bed3fde14d4eeb2bb1669c3c342eef369ce6165a0276
 

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -14,9 +14,6 @@ RUN { \
         echo 'opcache.fast_shutdown=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
-
-VOLUME /var/www/html
-
 ENV YOURLS_VERSION 1.7.4
 ENV YOURLS_SHA256 ffdf0f94b66cdbeaaa62bed3fde14d4eeb2bb1669c3c342eef369ce6165a0276
 


### PR DESCRIPTION
Hello!

We using docker-compose to debug application.
Defined volume caching on host and not changed after `docker-compose --build` command.

I don't see purpose for defining volume, but removing it will increase debug speed, i think.