### PR TITLE
Changes to support volume-mounted config file

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,7 +11,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		# if not specified, let's generate a random value
 		: "${YOURLS_COOKIEKEY:=$(head -c1m /dev/urandom | sha1sum | cut -d' ' -f1)}"
 
-		if [ ! -e /var/www/html/user/config.php ]; then
+		# We want to copy the initial config if the actual config file doesn't already
+		# exist OR if it is an empty file (e.g. it has been created for the volume mount).
+		if [ ! -e /var/www/html/user/config.php ] || [ ! -s /var/www/html/user/config.php ]; then
 			cp /var/www/html/user/config-docker.php /var/www/html/user/config.php
 			chown www-data:www-data /var/www/html/user/config.php
 		fi
@@ -19,7 +21,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 		: "${YOURLS_USER:=}"
 		: "${YOURLS_PASS:=}"
 		if [ -n "${YOURLS_USER}" ] && [ -n "${YOURLS_PASS}" ]; then
-			sed -i "s/  getenv('YOURLS_USER') => getenv('YOURLS_PASS'),/  '${YOURLS_USER}' => '${YOURLS_PASS}',/g" /var/www/html/user/config.php
+			result=$(sed "s/  getenv('YOURLS_USER') => getenv('YOURLS_PASS'),/  \'${YOURLS_USER}\' => \'${YOURLS_PASS}\',/g" /var/www/html/user/config.php)
+			echo "$result" > /var/www/html/user/config.php
 		fi
 
 		TERM=dumb php -- <<'EOPHP'


### PR DESCRIPTION
These changes allow the YOURLS Docker container to work with an initially-empty config file on the host that is then volume-mounted to /var/www/html/user/config.php

This fixes https://github.com/YOURLS/docker-yourls/issues/43.
