### PR TITLE
Default YOURLS_DB_PREFIX to blank as per documentation

### DIFF
--- a/config-docker.php
+++ b/config-docker.php
@@ -21,7 +21,7 @@ define( 'YOURLS_DB_NAME', getenv('YOURLS_DB_NAME') ?: 'yourls' );
 define( 'YOURLS_DB_HOST', getenv('YOURLS_DB_HOST') ?: 'mysql' );
 
 /** MySQL tables prefix */
-define( 'YOURLS_DB_PREFIX', getenv('YOURLS_DB_PREFIX') ?: 'yourls_' );
+define( 'YOURLS_DB_PREFIX', getenv('YOURLS_DB_PREFIX') ?: '' );
 
 /*
  ** Site options


### PR DESCRIPTION
Documentation at https://hub.docker.com/_/yourls/ states that YOURLS_DB_PREFIX should default to null.