### PR TITLE
This commit adds the ability to use SSL with MySQL.  The docker-entry…

### DIFF
--- a/db.php
+++ b/db.php
@@ -1,0 +1,22 @@
+<?php
+/*
+Plugin Name: Secure MySQL
+Plugin URI: https://github.com/YOURLS/YOURLS/issues/2783
+Description: SSL/TLS PDO Connection
+Version: 1.0
+Author: YOURLS
+Author URI: https://yourls.org/
+*/
+// No direct call
+if( !defined( 'YOURLS_ABSPATH' ) ) die();
+
+// Add custom cert
+yourls_add_filter( 'db_connect_driver_option', function ( $options ) {
+    // Add your certificate paths
+    // https://secure.php.net/manual/ref.pdo-mysql.php
+    return $options + [PDO::MYSQL_ATTR_SSL_CA=> "/etc/ssl/certs/db-ca.crt",];
+} );
+
+// Load DB layer as usual
+require_once YOURLS_INC.'/class-mysql.php';
+yourls_db_connect();

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -40,7 +40,7 @@ if (is_numeric($socket)) {
 	$socket = null;
 }
 
-$maxTries = 20;
+$maxTries = 10;
 do {
 
         $mysql = mysqli_init();

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -40,9 +40,13 @@ if (is_numeric($socket)) {
 	$socket = null;
 }
 
-$maxTries = 10;
+$maxTries = 20;
 do {
-	$mysql = new mysqli($host, YOURLS_DB_USER, YOURLS_DB_PASS, '', $port, $socket);
+
+        $mysql = mysqli_init();
+        if( file_exists("/etc/ssl/certs/db-ca.crt") ) { $mysql->ssl_set(NULL, NULL, "/etc/ssl/certs/db-ca.crt", NULL, NULL); }
+        $mysql->real_connect($host, YOURLS_DB_USER, YOURLS_DB_PASS, YOURLS_DB_NAME, $port);
+
 	if ($mysql->connect_error) {
 		fwrite($stderr, "\nMySQL Connection Error: ({$mysql->connect_errno}) {$mysql->connect_error}\n");
 		--$maxTries;


### PR DESCRIPTION
…point.sh script has been modified to use mysqli and real_connect instead of the mysqli function itself.  This was done so that we can add support for adding a path /etc/ssl/certs/db-ca.crt.  The PHP uses a file_exists function to verify it exists before adding it into the code.  This cert needs to be mounted to the docker container using a volume mount:

	-v /path/to/cert/ca.crt:/etc/ssl/certs/db-ca.crt

Additionally, the yourls code needs an additional piece to tell the PDO driver to use the same cert for verification.  This file was included as db.php and must also be mounted with a volume mount:

        -v /path/to/db.php:/var/www/html/user/db.php