### PR TITLE
Remove database check at container startup

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env bash
+set -Eeuo pipefail
 
 if [ ! -e /var/www/html/yourls-loader.php ]; then
 	tar cf - --one-file-system -C /usr/src/yourls . | tar xf -
@@ -24,43 +24,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 			result=$(sed "s/  getenv_docker('YOURLS_USER') => getenv_docker('YOURLS_PASS'),/  \'${YOURLS_USER}\' => \'${YOURLS_PASS}\',/g" /var/www/html/user/config.php)
 			echo "$result" > /var/www/html/user/config.php
 		fi
-
-		TERM=dumb php -- <<'EOPHP'
-<?php
-// database might not exist, so let's try creating it (just to be safe)
-
-$stderr = fopen('php://stderr', 'w');
-
-require '/var/www/html/user/config.php';
-
-list($host, $socket) = explode(':', YOURLS_DB_HOST, 2);
-$port = 0;
-if (is_numeric($socket)) {
-	$port = (int) $socket;
-	$socket = null;
-}
-
-$maxTries = 10;
-do {
-	$mysql = new mysqli($host, YOURLS_DB_USER, YOURLS_DB_PASS, '', $port, $socket);
-	if ($mysql->connect_error) {
-		fwrite($stderr, "\nMySQL Connection Error: ({$mysql->connect_errno}) {$mysql->connect_error}\n");
-		--$maxTries;
-		if ($maxTries <= 0) {
-			exit(1);
-		}
-		sleep(3);
-	}
-} while ($mysql->connect_error);
-
-if (!$mysql->query('CREATE DATABASE IF NOT EXISTS `'.$mysql->real_escape_string(YOURLS_DB_NAME).'`')) {
-	fwrite($stderr, "\nMySQL \"CREATE DATABASE\" Error: {$mysql->error}\n");
-	$mysql->close();
-	exit(1);
-}
-
-$mysql->close();
-EOPHP
 	fi
 fi
 


### PR DESCRIPTION
Almost unnecessary for most of the time and might raise a lot of incompatibility issues with other database drivers.

Also closes #98
Ref https://github.com/docker-library/wordpress/pull/557